### PR TITLE
Add a few new options:

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ plugins: [
             ],
             createLinkInHead: true, // optional: create a link in the `<head>` of your site
             addUncaughtPages: true, // optional: will fill up pages that are not caught by queries and mapping and list them under `sitemap-pages.xml`
+            hideAttribution: false, // optional: hide "Ghost" attribution line from XSL stylesheet
+            resultKey: null, // optional: access for query data not at root, but instead under a container key (i.e. 'postgres')
+            stripTrailingSlash: false, // optional: make sure to strip trailing slashes from uncaught siteAllPage urls
             additionalSitemaps: [ // optional: add additional sitemaps, which are e. g. generated somewhere else, but need to be indexed for this domain
                 {
                     name: `my-other-posts`,


### PR DESCRIPTION
  * `hideAttribution` boolean = optional: hide "Ghost" attribution line from
      XSL stylesheet.
  * `resultKey` string = optional: access for query data not at root, but
      instead under a container key (i.e. 'postgres').
  * `stripTrailingSlash` boolean = optional: make sure to strip trailing
      slashes from uncaught siteAllPage urls.