### PR TITLE
Updated README.md for Gatsby Community Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ _NOTE: This plugin only generates output in `production` mode! To test, run: `ga
 
 ## Install
 
-`npm install --save gatsby-plugin-advanced-sitemap`
+`npm install --save gatsby-plugin-advanced-sitemap-mod`
 
 ## How to Use
 
@@ -42,7 +42,7 @@ siteMetadata: {
     siteUrl: `https://www.example.com`,
 },
 plugins: [
-    `gatsby-plugin-advanced-sitemap`
+    `gatsby-plugin-advanced-sitemap-mod`
 ]
 ```
 
@@ -59,7 +59,7 @@ If you want to generate advanced, individually organised sitemaps based on your 
 
 plugins: [
     {
-        resolve: `gatsby-plugin-advanced-sitemap`,
+        resolve: `gatsby-plugin-advanced-sitemap-mod`,
         options: {
              // 1 query for each data type
             query: `


### PR DESCRIPTION
Clarification on how to properly install it as seen on gatsbyjs.com/plugins/gatsby-plugin-advanced-sitemap-mod/ since the instruction is still showing gatsby-plugin-advanced-sitemap's original install instructions.